### PR TITLE
Fix issue with country whitelisting

### DIFF
--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -162,7 +162,7 @@ class Config {
 
   set countryWhitelist(List<String> countryWhitelist) {
     assertValidityOfCountryCodes(countryWhitelist, 'countryWhitelist');
-    _countryWhitelist = countryBlacklist;
+    _countryWhitelist = countryWhitelist;
   }
 
   List<String> get countryWhitelist {


### PR DESCRIPTION
The setter for country whitelist sets the value of countryBlacklist in the countryWhitelist attribute. This prevents the user from whitelisting a set of countries.

This PR is to fix this.