### PR TITLE
Fix authorization code truncation issue

### DIFF
--- a/android/src/main/java/com/peerwaya/flutteraccountkit/LoginResults.java
+++ b/android/src/main/java/com/peerwaya/flutteraccountkit/LoginResults.java
@@ -24,7 +24,7 @@ public class LoginResults {
                 put("accessToken", accessTokenMap);
             }};
         } else {
-            final String code = loginResult.getAuthorizationCode().substring(0, 10);
+            final String code = loginResult.getAuthorizationCode();
             final String state = loginResult.getFinalAuthorizationState();
             return new HashMap<String, Object>() {{
                 put("status", "loggedIn");


### PR DESCRIPTION
In the ResponseType.code flow the authorization code is getting truncated to a length of 10 characters. This commit fixes that issue so that complete authorization code is retrievable.